### PR TITLE
Fix missing version or creator nodes

### DIFF
--- a/lib/src/gpx_reader.dart
+++ b/lib/src/gpx_reader.dart
@@ -37,10 +37,10 @@ class GpxReader {
     final gpx = Gpx();
 
     gpx.version = gpxTag.attributes
-        .firstWhere((attr) => attr.name == GpxTagV11.version)
+        .firstWhere((attr) => attr.name == GpxTagV11.version, orElse: () => XmlEventAttribute(GpxTagV11.version, '1.1', XmlAttributeType.DOUBLE_QUOTE))
         .value;
     gpx.creator = gpxTag.attributes
-        .firstWhere((attr) => attr.name == GpxTagV11.creator)
+        .firstWhere((attr) => attr.name == GpxTagV11.creator, orElse: () => XmlEventAttribute(GpxTagV11.creator, 'unknown', XmlAttributeType.DOUBLE_QUOTE))
         .value;
 
     while (iterator.moveNext()) {


### PR DESCRIPTION
Based on https://github.com/BorisLok/dart-gpx/commit/0f6b2a99b1399ce276a49720bd7b4cb413bc588f

As @BorisLok said: 

>[Cause] if the gpx didn't contain the version of xml, or creator, it
will crash.

[Solution] give it default value.